### PR TITLE
Compile build dependencies independently

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,6 @@ jobs:
           - { python: "3.8", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "windows-latest", session: "tests" }
           - { python: "3.12", os: "macos-latest", session: "tests" }
-          - { python: "3.12", os: "ubuntu-latest", session: "typeguard" }
           - { python: "3.12", os: "ubuntu-latest", session: "xdoctest" }
           - { python: "3.12", os: "ubuntu-latest", session: "docs-build" }
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,6 @@ nox.options.sessions = (
     "pre-commit",
     "safety",
     "tests",
-    "typeguard",
     "xdoctest",
     "docs-build",
 )
@@ -160,14 +159,6 @@ def coverage(session: Session) -> None:
         session.run("coverage", "combine")
 
     session.run("coverage", *args)
-
-
-@session(python=python_versions[0])
-def typeguard(session: Session) -> None:
-    """Runtime type checking using Typeguard."""
-    session.install(".")
-    session.install("typeguard", *test_requirements)
-    session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 
 @session(python=python_versions)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1973,24 +1973,24 @@ python-versions = ">=3.6"
 files = [
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d92f81886165cb14d7b067ef37e142256f1c6a90a65cd156b063a43da1708cfd"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
-    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
     {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b5edda50e5e9e15e54a6a8a0070302b00c518a9d32accc2346ad6c984aacd279"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
-    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
     {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7048c338b6c86627afb27faecf418768acb6331fc24cfa56c93e8c9780f815fa"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
-    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
     {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
@@ -1998,7 +1998,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
-    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3fcc54cb0c8b811ff66082de1680b4b14cf8a81dce0d4fbf665c2265a81e07a1"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
@@ -2006,7 +2006,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
-    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:665f58bfd29b167039f714c6998178d27ccd83984084c286110ef26b230f259f"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
@@ -2014,7 +2014,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
-    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9eb5dee2772b0f704ca2e45b1713e4e5198c18f515b52743576d196348f374d3"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
     {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
@@ -2405,25 +2405,6 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
-name = "typeguard"
-version = "4.3.0"
-description = "Run-time type checker for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "typeguard-4.3.0-py3-none-any.whl", hash = "sha256:4d24c5b39a117f8a895b9da7a9b3114f04eb63bade45a4492de49b175b6f7dfa"},
-    {file = "typeguard-4.3.0.tar.gz", hash = "sha256:92ee6a0aec9135181eae6067ebd617fd9de8d75d714fb548728a4933b1dea651"},
-]
-
-[package.dependencies]
-importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
-typing-extensions = ">=4.10.0"
-
-[package.extras]
-doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
-test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
-
-[[package]]
 name = "typer"
 version = "0.12.3"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -2569,4 +2550,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "080b54068fe08620246905382d596637002218d70c924ebd7ca5c0eb877ea2a3"
+content-hash = "a0f8563d3c047bcc50d52e595069576e38b13d77b93c2780cd40dfabf929d4a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ safety = ">=1.10.3"
 sphinx = ">=4.3.2"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-click = ">=3.0.2"
-typeguard = ">=2.13.3"
 xdoctest = { extras = ["colors"], version = ">=0.15.10" }
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuild-deps"
-version = "0.2.0"
+version = "0.3.0"
 description = "A simple tool for detection of PEP-517 build dependencies."
 authors = ["Bruno Ciconelle <bciconel@redhat.com>"]
 license = "GPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ source = ["pybuild_deps", "tests"]
 
 [tool.coverage.report]
 show_missing = true
-# FixME: dial this back up to 100
-fail_under = 98
+fail_under = 100
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/src/pybuild_deps/compile_build_dependencies.py
+++ b/src/pybuild_deps/compile_build_dependencies.py
@@ -17,6 +17,7 @@ from pip._internal.req.constructors import install_req_from_req_string
 from pip._vendor.resolvelib.resolvers import ResolutionImpossible
 from piptools.repositories import PyPIRepository
 from piptools.resolver import BacktrackingResolver
+from piptools.utils import key_from_ireq
 
 from .exceptions import UnsolvableDependenciesError
 from .finder import find_build_dependencies
@@ -30,29 +31,38 @@ class BuildDependencyCompiler:
     def __init__(self, repository: PyPIRepository) -> None:
         self.repository = repository
         self.resolver = None
-        self.dependency_cache = {}
 
     def resolve(
         self,
         install_requirements: Iterable[InstallRequirement],
+        existing_constraints: dict[str, InstallRequirement] | None = None,
+        dependency_cache: dict[str, InstallRequirement] | None = None,
     ) -> set[InstallRequirement]:
         """Resolve all build dependencies for a given set of dependencies."""
         all_build_deps = []
+
+        # reuse or initialize constraints (following what piptools expects downstream)
+        # and our dependency cache
+        existing_constraints = existing_constraints or {
+            key_from_ireq(ireq): ireq for ireq in install_requirements
+        }
+        dependency_cache = dependency_cache or {}
+
         for ireq in install_requirements:
             log.info("=" * 80)
             log.info(str(ireq))
             log.info("-" * 80)
             req_version = get_version(ireq)
             ireq_name = f"{ireq.name}=={req_version}"
-            if ireq_name in self.dependency_cache:
-                all_build_deps.extend(self.dependency_cache[ireq_name])
-                log.debug(f"{ireq} exists in our cache, moving on...")
+            if ireq_name in dependency_cache:
+                all_build_deps.extend(dependency_cache[ireq_name])
+                log.debug(f"{ireq} was already solved, moving on...")
                 continue
             raw_build_dependencies = find_build_dependencies(
                 ireq.name, req_version, raise_setuppy_parsing_exc=False
             )
             if not raw_build_dependencies:
-                self.dependency_cache[ireq_name] = set()
+                dependency_cache[ireq_name] = set()
                 continue
             # 'find_build_dependencies' is very naive - by design - and only returns
             # a simple list of strings representing build (or transitive) dependencies.
@@ -63,32 +73,60 @@ class BuildDependencyCompiler:
                 partial(install_req_from_req_string, comes_from=ireq.name),
                 raw_build_dependencies,
             )
-            build_dependencies = self._resolve_with_piptools(
-                package=ireq_name, ireqs=build_ireqs
-            )
+            try:
+                # Attempt to resolve ireq's transitive dependencies using
+                # runtime requirements as constraint. This is equivalent to
+                # running "pip install -c constraints-file.txt".
+                build_dependencies = self._resolve_with_piptools(
+                    package=ireq_name,
+                    ireqs=build_ireqs,
+                    constraints=existing_constraints,
+                )
+            except UnsolvableDependenciesError:
+                # Being unsolvable on the previous step doesn't mean a transitive
+                # dependency is actually unsolvable. Per PEP-517, transitive
+                # dependencies are built in isolated environments. We only
+                # try building with constraints to avoid ending up with an unnecessarily
+                # large list of dependencies to manage.
+
+                # If this step fails, the same exception will bubble up and explode
+                # in an error.
+                build_dependencies = self._resolve_with_piptools(
+                    package=ireq_name,
+                    ireqs=build_ireqs,
+                )
+
             # dependencies of build dependencies might have their own build
             # dependencies, so let's recursively search for those.
             build_deps_qty = 0
             while len(build_dependencies) != build_deps_qty:
                 build_deps_qty = len(build_dependencies)
-                build_dependencies |= set(self.resolve(build_dependencies))
-            self.dependency_cache[ireq_name] = build_dependencies
+                build_dependencies |= self.resolve(
+                    build_dependencies,
+                    existing_constraints=existing_constraints,
+                    dependency_cache=dependency_cache,
+                )
+
+            dependency_cache[ireq_name] = build_dependencies
 
             all_build_deps.extend(build_dependencies)
 
         return deduplicate_install_requirements(all_build_deps)
 
     def _resolve_with_piptools(
-        self, package: str, ireqs: Iterable[InstallRequirement]
+        self,
+        package: str,
+        ireqs: Iterable[InstallRequirement],
+        constraints: set[InstallRequirement],
     ) -> set[InstallRequirement]:
         # backup unsafe data before overriding resolver, we will need it later
         # on piptools writer to export the file
         unsafe_packages = getattr(self.resolver, "unsafe_packages", set())
         unsafe_constraints = getattr(self.resolver, "unsafe_constraints", set())
-        # override resolver - we only want the latest and greatest
+        # override resolver - we don't want references from other
         self.resolver = BacktrackingResolver(
             constraints=ireqs,
-            existing_constraints={},
+            existing_constraints=constraints,
             repository=self.repository,
             allow_unsafe=True,
         )

--- a/src/pybuild_deps/compile_build_dependencies.py
+++ b/src/pybuild_deps/compile_build_dependencies.py
@@ -19,6 +19,7 @@ from piptools.resolver import BacktrackingResolver
 
 from .exceptions import UnsolvableDependenciesError
 from .finder import find_build_dependencies
+from .logger import log
 from .utils import get_version
 
 
@@ -28,46 +29,77 @@ class BuildDependencyCompiler:
     def __init__(self, repository: PyPIRepository) -> None:
         self.repository = repository
         self.resolver = None
+        self.dependency_cache = {}
 
     def resolve(
         self,
         install_requirements: Iterable[InstallRequirement],
-        constraints: Iterable[InstallRequirement] | None = None,
     ) -> set[InstallRequirement]:
         """Resolve all build dependencies for a given set of dependencies."""
-        constraints: list[InstallRequirement] = list(constraints) if constraints else []
-        constraint_qty = len(constraints)
-        for req in install_requirements:
-            req_version = get_version(req)
+        all_build_deps = []
+        for ireq in install_requirements:
+            log.info("=" * 80)
+            log.info(str(ireq))
+            log.info("-" * 80)
+            req_version = get_version(ireq)
+            version_tuple = ireq.name, req_version
+            if version_tuple in self.dependency_cache:
+                all_build_deps.extend(self.dependency_cache[version_tuple])
+                log.debug(f"{ireq} exists in our cache, moving on...")
+                continue
             raw_build_dependencies = find_build_dependencies(
-                req.name, req_version, raise_setuppy_parsing_exc=False
+                ireq.name, req_version, raise_setuppy_parsing_exc=False
             )
+            if not raw_build_dependencies:
+                self.dependency_cache[version_tuple] = set()
+                continue
+
+            constraints = []
             for raw_build_req in raw_build_dependencies:
                 build_req = install_req_from_req_string(
-                    raw_build_req, comes_from=req.name
+                    raw_build_req, comes_from=ireq.name
                 )
                 constraints.append(build_req)
-        # override resolver - we only want the latest and greatest
-        self.resolver = BacktrackingResolver(
-            constraints=constraints,
-            existing_constraints={},
-            repository=self.repository,
-            allow_unsafe=True,
-        )
-        try:
-            build_dependencies = self.resolver.resolve()
-        except DistributionNotFound as err:
-            if isinstance(err.__cause__, ResolutionImpossible):  # pragma: no cover
-                unsolvable_deps = err.__cause__.args
-                raise UnsolvableDependenciesError(  # noqa: B904
-                    unsolvable_deps, constraints
-                )
-            raise err
-        # dependencies of build dependencies might have their own build dependencies,
-        # so let's recursively search for those.
-        while len(build_dependencies) != constraint_qty:
-            constraint_qty = len(build_dependencies)
-            build_dependencies = self.resolve(
-                build_dependencies, constraints=build_dependencies
+            # override resolver - we only want the latest and greatest
+            self.resolver = BacktrackingResolver(
+                constraints=constraints,
+                existing_constraints={},
+                repository=self.repository,
+                allow_unsafe=True,
             )
-        return build_dependencies
+            try:
+                build_dependencies = self.resolver.resolve()
+            except DistributionNotFound as err:
+                if isinstance(err.__cause__, ResolutionImpossible):  # pragma: no cover
+                    unsolvable_deps = err.__cause__.args
+                    raise UnsolvableDependenciesError(  # noqa: B904
+                        unsolvable_deps, constraints
+                    )
+                raise err
+            # dependencies of build dependencies might have their own build
+            # dependencies, so let's recursively search for those.
+            build_deps_qty = 0
+            while len(build_dependencies) != build_deps_qty:
+                build_deps_qty = len(build_dependencies)
+                build_dependencies |= set(self.resolve(build_dependencies))
+            self.dependency_cache[version_tuple] = build_dependencies
+            all_build_deps.extend(build_dependencies)
+        return deduplicate_install_requirements(all_build_deps)
+
+
+def deduplicate_install_requirements(ireqs: Iterable[InstallRequirement]):
+    """Deduplicate InstallRequirements."""
+    unique_ireqs = {}
+    for ireq in ireqs:
+        version_tuple = ireq.name, get_version(ireq)
+        if version_tuple not in unique_ireqs:
+            # NOTE: piptools hacks pip's InstallRequirement to allow support from
+            # multiple sources. Let's use the same attr so piptools file writer can
+            # use this information.
+            # https://github.com/jazzband/pip-tools/blob/53309647980e2a4981db54c0033f98c61142de0b/piptools/resolver.py#L118-L122
+            # https://github.com/jazzband/pip-tools/blob/53309647980e2a4981db54c0033f98c61142de0b/piptools/writer.py#L309-L314
+            ireq._source_ireqs = getattr(ireq, "_source_ireqs", [ireq])
+            unique_ireqs[version_tuple] = ireq
+        else:
+            unique_ireqs[version_tuple]._source_ireqs.append(ireq)
+    return set(unique_ireqs.values())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -197,7 +197,8 @@ def test_compile_unsolvable_dependencies(runner: CliRunner, tmp_path: Path, mock
     result = runner.invoke(main.cli, args=["compile", "-o", str(outfile)])
     assert result.exit_code == 2
     assert (
-        "Impossible to resolve the following dependencies for package 'foo==0.1.2':\n"
-        "setuptools>=42\n"
-        "setuptools<42" in result.stderr
+        "Impossible to resolve the following dependencies for package 'foo==0.1.2'"
+        in result.stderr
     )
+    assert "setuptools>=42" in result.stderr
+    assert "setuptools<42" in result.stderr

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -192,11 +192,12 @@ def test_compile_unsolvable_dependencies(runner: CliRunner, tmp_path: Path, mock
     outfile = tmp_path / "outfile"
     mocker.patch(
         "pybuild_deps.compile_build_dependencies.find_build_dependencies",
-        return_value=["bar>=42", "bar<42"],
+        return_value=["setuptools>=42", "setuptools<42"],
     )
     result = runner.invoke(main.cli, args=["compile", "-o", str(outfile)])
     assert result.exit_code == 2
     assert (
-        "Impossible resolve dependencies. See the conflicting dependencies "
-        "below:\nbar>=42 (from foo)\nbar<42 (from foo)" in result.stderr
+        "Impossible to resolve the following dependencies for package 'foo==0.1.2':\n"
+        "setuptools>=42\n"
+        "setuptools<42" in result.stderr
     )


### PR DESCRIPTION
pybuild-deps used to try to attempt to solve all build dependencies together, which was a design flaw and was causing issues.

Transitive dependencies aren't necessarily consistent. When pip is building packages it will build each in an isolated environment. Transitive dependencies won't be required for the prepared wheel.

 With this PR this behavior is completely modified. Now build dependencies will be resolved independently. In order to avoid generating a longer list of dependencies, it will use the supplied requirements as optional constraints.