### PR TITLE
feature: add support for zipped sdists and pinned url dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuild-deps"
-version = "0.3.0"
+version = "0.4.0"
 description = "A simple tool for detection of PEP-517 build dependencies."
 authors = ["Bruno Ciconelle <bciconel@redhat.com>"]
 license = "GPL-3.0"

--- a/src/pybuild_deps/compile_build_dependencies.py
+++ b/src/pybuild_deps/compile_build_dependencies.py
@@ -167,7 +167,10 @@ class BuildDependencyCompiler:
         """Find build dependencies for a given ireq."""
         ireq_version = get_version(ireq)
         for build_dep in find_build_dependencies(
-            ireq.name, ireq_version, raise_setuppy_parsing_exc=False
+            ireq.name,
+            ireq_version,
+            raise_setuppy_parsing_exc=False,
+            pip_session=self.repository.session,
         ):
             # The original 'find_build_dependencies' function is very naive by design.
             # It only returns a simple list of strings representing builds dependencies.

--- a/src/pybuild_deps/finder.py
+++ b/src/pybuild_deps/finder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import tarfile
 
+from pip._internal.network.session import PipSession
+
 from pybuild_deps.parsers.setup_py import SetupPyParsingError
 
 from .logger import log
@@ -12,7 +14,10 @@ from .source import get_package_source
 
 
 def find_build_dependencies(
-    package_name, version, raise_setuppy_parsing_exc=True
+    package_name,
+    version,
+    raise_setuppy_parsing_exc=True,
+    pip_session: PipSession | None = None,
 ) -> list[str]:
     """Find build dependencies for a given package."""
     file_parser_map = {
@@ -21,7 +26,7 @@ def find_build_dependencies(
         "setup.py": parse_setup_py,
     }
     log.debug(f"retrieving source for package {package_name}=={version}")
-    source_path = get_package_source(package_name, version)
+    source_path = get_package_source(package_name, version, pip_session=pip_session)
     build_dependencies = []
     with tarfile.open(fileobj=source_path.open("rb")) as tarball:
         for file_name, parser in file_parser_map.items():

--- a/src/pybuild_deps/parsers/requirements.py
+++ b/src/pybuild_deps/parsers/requirements.py
@@ -14,7 +14,7 @@ from pip._internal.req.constructors import (
 )
 
 from pybuild_deps.exceptions import PyBuildDepsError
-from pybuild_deps.utils import is_pinned_requirement
+from pybuild_deps.utils import is_supported_requirement
 
 
 def parse_requirements(
@@ -31,7 +31,7 @@ def parse_requirements(
         filename, session, finder=finder, options=options, constraint=constraint
     ):
         ireq = install_req_from_parsed_requirement(parsed_req, isolated=isolated)
-        if not is_pinned_requirement(ireq):
+        if not is_supported_requirement(ireq):
             raise PyBuildDepsError(
                 f"requirement '{ireq}' is not exact "
                 "(pybuild-tools only supports pinned dependencies)."

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,27 @@ def test_main_succeeds(runner: CliRunner) -> None:
                 "setuptools-rust>=0.11.4",
             ],
         ),
+        (
+            "cryptography",
+            "git+https://github.com/pyca/cryptography@41.0.5",
+            [
+                "setuptools>=61.0.0",
+                "wheel",
+                "cffi>=1.12; platform_python_implementation != 'PyPy'",
+                "setuptools-rust>=0.11.4",
+            ],
+        ),
+        (
+            "cryptography",
+            "https://github.com/pyca/cryptography/archive/refs/tags/43.0.0.tar.gz",
+            [
+                "maturin>=1,<2",
+                "cffi>=1.12; platform_python_implementation != 'PyPy'",
+                "setuptools",
+            ],
+        ),
+        ("azure-identity", "1.14.1", []),
+        ("debugpy", "1.8.5", ["wheel", "setuptools"]),
     ],
 )
 def test_find_build_deps(
@@ -68,7 +89,7 @@ def test_find_build_deps(
     assert result.exit_code == 0
     assert result.stdout.splitlines() == expected_deps
     assert cache.exists()
-    # repeating the same test to cover a cached version
+    # repeating the same test to cover the cached version
     result = runner.invoke(main.cli, args=["find-build-deps", package_name, version])
     assert result.exit_code == 0
     assert result.stdout.splitlines() == expected_deps
@@ -90,12 +111,17 @@ def test_find_build_deps(
         (
             "some-package",
             "git+https://example.com",
-            "Unsupported requirement (some-package @ git+https://example.com). Url requirements must use a VCS scheme like 'git+https'.",  # noqa: E501
+            "Unsupported requirement 'some-package@ git+https://example.com'. Requirement must be either pinned (==), a vcs link with sha or a direct url.",  # noqa: E501
+        ),
+        (
+            "some-package",
+            "https://example.com",
+            "Unable to unpack 'some-package@ https://example.com'. Is 'https://example.com' a python package?",  # noqa: E501
         ),
         (
             "cryptography",
             "git+https://github.com/pyca/cryptography",
-            "Unsupported requirement (cryptography @ git+https://github.com/pyca/cryptography). Url requirements must use a VCS scheme like 'git+https'.",  # noqa: E501
+            "Unsupported requirement 'cryptography@ git+https://github.com/pyca/cryptography'. Requirement must be either pinned (==), a vcs link with sha or a direct url.",  # noqa: E501
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 import pytest
 from pip._internal.req.constructors import install_req_from_req_string
 
-from pybuild_deps.utils import get_version, is_pinned_requirement
+from pybuild_deps.utils import get_version, is_supported_requirement
 
 
 @pytest.mark.parametrize(
@@ -16,7 +16,7 @@ from pybuild_deps.utils import get_version, is_pinned_requirement
 def test_is_pinned_or_vcs(req):
     """Ensure pinned or vcs dependencies are properly detected."""
     ireq = install_req_from_req_string(req)
-    assert is_pinned_requirement(ireq)
+    assert is_supported_requirement(ireq)
 
 
 @pytest.mark.parametrize(
@@ -24,15 +24,13 @@ def test_is_pinned_or_vcs(req):
     [
         "requests>1.2.3",
         "requests @ git+https://github.com/psf/requests",
-        "requests @ https://example.com",
-        "requests @ https://github.com/psf/requests@some-commit-sha",
         "requests",
     ],
 )
 def test_not_pinned_or_vcs(req):
     """Negative test for 'is_pinned_or_vcs'."""
     ireq = install_req_from_req_string(req)
-    assert not is_pinned_requirement(ireq)
+    assert not is_supported_requirement(ireq)
 
 
 def test_get_version_url():


### PR DESCRIPTION
Modified pybuild-deps internals to rely more on pip internals, which gave us both support for url dependencies and zip archived packages for "free". This should fix (or at least cover most of) issues #188 and #187.