### PR TITLE
Fix an issue causing inconsistent annotations and ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuild-deps"
-version = "0.4.0"
+version = "0.4.1"
 description = "A simple tool for detection of PEP-517 build dependencies."
 authors = ["Bruno Ciconelle <bciconel@redhat.com>"]
 license = "GPL-3.0"

--- a/src/pybuild_deps/compile_build_dependencies.py
+++ b/src/pybuild_deps/compile_build_dependencies.py
@@ -179,10 +179,10 @@ class BuildDependencyCompiler:
             yield install_req_from_req_string(build_dep, comes_from=ireq.name)
 
 
-def deduplicate_install_requirements(ireqs: Iterable[InstallRequirement]):
+def deduplicate_install_requirements(_ireqs: Iterable[InstallRequirement]):
     """Deduplicate InstallRequirements."""
     unique_ireqs = {}
-    for ireq in ireqs:
+    for ireq in _ireqs:
         req_tuple = ireq.name, get_version(ireq)
         if req_tuple not in unique_ireqs:
             # NOTE: piptools hacks pip's InstallRequirement to allow support from
@@ -190,8 +190,9 @@ def deduplicate_install_requirements(ireqs: Iterable[InstallRequirement]):
             # use this information.
             # https://github.com/jazzband/pip-tools/blob/53309647980e2a4981db54c0033f98c61142de0b/piptools/resolver.py#L118-L122
             # https://github.com/jazzband/pip-tools/blob/53309647980e2a4981db54c0033f98c61142de0b/piptools/writer.py#L309-L314
-            ireq._source_ireqs = getattr(ireq, "_source_ireqs", [ireq])
+            ireq._source_ireqs = set(getattr(ireq, "_source_ireqs", {ireq}))
             unique_ireqs[req_tuple] = ireq
         else:
-            unique_ireqs[req_tuple]._source_ireqs.append(ireq)
+            _ireqs = set(getattr(ireq, "_source_ireqs", {ireq}))
+            unique_ireqs[req_tuple]._source_ireqs |= _ireqs
     return set(unique_ireqs.values())

--- a/src/pybuild_deps/scripts/compile.py
+++ b/src/pybuild_deps/scripts/compile.py
@@ -16,7 +16,7 @@ from piptools.utils import get_compile_command as _get_compile_command
 from piptools.utils import (
     key_from_ireq,
 )
-from piptools.writer import OutputWriter
+from piptools.writer import OutputWriter as PipToolsWriter
 
 from pybuild_deps.compile_build_dependencies import (
     BuildDependencyCompiler,
@@ -25,6 +25,7 @@ from pybuild_deps.constants import PIP_CACHE_DIR
 from pybuild_deps.exceptions import PyBuildDepsError
 from pybuild_deps.logger import log
 from pybuild_deps.parsers import parse_requirements
+from pybuild_deps.utils import get_version
 
 
 REQUIREMENTS_TXT = "requirements.txt"
@@ -189,3 +190,10 @@ def _handle_src_files():
         )
 
     return src_files
+
+
+class OutputWriter(PipToolsWriter):
+    """pip-tools OutputWriter with customizations for pybuild-deps."""
+
+    def _sort_key(self, ireq: InstallRequirement) -> tuple[bool, str]:
+        return (not ireq.editable, f"{ireq.name}=={get_version(ireq)}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 """Test cases for the __main__ module."""
 
+import traceback
 from os import chdir
 from pathlib import Path
 
@@ -146,7 +147,7 @@ def test_compile_greenpath(
     result = runner.invoke(
         main.cli, args=["compile", str(requirements_path), "-o", str(output)]
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, traceback.print_tb(result.exc_info[2])
     expected_packages = {"setuptools-rust", "setuptools-scm"}
     build_requirements = list(parse_requirements(str(output), pypi_repo.session))
     assert expected_packages.issubset({r.name for r in build_requirements})


### PR DESCRIPTION
Fix a bug in the compile script that was causing variations in the metadata of generated `requirements-build.txt` files.

Also, fix a bug causing packages in `requirements-build.txt` to be randomly ordered.